### PR TITLE
Update functions bp_activity_user_can_delete & bp_activity_user_can_edit

### DIFF
--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -1629,11 +1629,13 @@ function bp_activity_user_can_delete( $activity = false ) {
 		if ( bp_current_user_can( 'bp_moderate' ) ) {
 			$can_delete = true;
 		}
+		 // @oli-bee is current usr member of the group ? 
+		$is_member = groups_is_user_member( $activity->user_id, $activity->item_id );
 
 		// Users are allowed to delete their own activity. This is actually
 		// quite powerful, because doing so also deletes all comments to that
 		// activity item. We should revisit this eventually.
-		if ( isset( $activity->user_id ) && ( $activity->user_id === bp_loggedin_user_id() ) ) {
+		if ( isset( $activity->user_id ) && ( $activity->user_id === bp_loggedin_user_id() ) && $is_member ) {
 			$can_delete = true;
 		}
 
@@ -1683,9 +1685,10 @@ function bp_activity_user_can_edit( $activity = false, $privacy_edit = false ) {
 
 	// Only logged in users can edit activity and Activity must be of type 'activity_update', 'activity_comment'
 	if ( is_user_logged_in() && in_array( $activity->type, array( 'activity_update', 'activity_comment' ) ) ) {
-
+         // @oli-bee is current usr member of the group ? 
+		$is_member = groups_is_user_member( $activity->user_id, $activity->item_id );
 		// Users are allowed to edit their own activity.
-		if ( isset( $activity->user_id ) && ( bp_loggedin_user_id() === $activity->user_id ) ) {
+		if ( isset( $activity->user_id ) && ( bp_loggedin_user_id() === $activity->user_id ) && $is_member ) {
 			$can_edit = true;
 		}
 

--- a/src/bp-media/bp-media-functions.php
+++ b/src/bp-media/bp-media-functions.php
@@ -3690,8 +3690,10 @@ function bb_media_user_can_access( $id, $type, $attachment_id = 0 ) {
 
 				$is_admin = groups_is_user_admin( $current_user_id, $media_group_id );
 				$is_mod   = groups_is_user_mod( $current_user_id, $media_group_id );
+				// is current user still member of the group ?
+				$is_member = groups_is_user_member($current_user_id, $media_group_id);
 
-				if ( $media_user_id === $current_user_id || $is_admin ) {
+				if ( $media_user_id === $current_user_id && $is_member|| $is_admin ) {
 					$can_view     = true;
 					$can_download = true;
 					$can_add      = true;


### PR DESCRIPTION
Add a test to check if current user in the activity loop can edit or delete an activity of a group is not anymore member

### Jira Issue:
<!-- Paste Jira issue link -->


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
